### PR TITLE
Feature/formatters

### DIFF
--- a/airbag/messagebag.py
+++ b/airbag/messagebag.py
@@ -20,11 +20,11 @@ m {0}'
 out'
         self.errmessages[ErrorType.SIGNALED] = 'Killed by signal {0}'
         self.errmessages[ErrorType.STDOUT_DIFFERS] = 'Standard output differs\n\
-Expected:\n{0}\nGot:\n{1}\n'
+Expected:\n{0}\nGot:\n{1}'
         self.errmessages[ErrorType.STDERR_DIFFERS] = 'Standard error differs\n\
-Expected:\n{0}\nGot:\n{1}\n'
+Expected:\n{0}\nGot:\n{1}'
         self.errmessages[ErrorType.RETURN_CODE_DIFFERS] = 'Return code differs\
-\nExpected:\n{0}\nGot:\n{1}\n'
+\nExpected:\n{0}\nGot:\n{1}'
 
     def get_status_str(self, status):
         return self.status_messages[status]

--- a/airbag/messagebag.py
+++ b/airbag/messagebag.py
@@ -1,0 +1,33 @@
+from .status import ExitStatus
+from .result import ErrorType
+
+
+class MessageBag(object):
+    def __init__(self):
+        super(MessageBag, self).__init__()
+        self.status_messages = {}
+        self.status_messages[ExitStatus.OK] = 'OK'
+        self.status_messages[ExitStatus.finished] = 'KO'
+        self.status_messages[ExitStatus.killed] = 'KO'
+        self.status_messages[ExitStatus.timeout] = 'KO'
+        self.status_messages[ExitStatus.noexec] = 'KO'
+        self.errmessages = {}
+        self.errmessages[ErrorType.FILE_NOT_FOUND] = 'Couldn\'t find the progra\
+m {0}'
+        self.errmessages[ErrorType.NO_RIGHTS] = 'Couldn\'t execute the program \
+{0}'
+        self.errmessages[ErrorType.TIMEOUT] = 'Execution exceeded the {0}s time\
+out'
+        self.errmessages[ErrorType.SIGNALED] = 'Killed by signal {0}'
+        self.errmessages[ErrorType.STDOUT_DIFFERS] = 'Standard output differs\n\
+Expected:\n{0}\nGot:\n{1}\n'
+        self.errmessages[ErrorType.STDERR_DIFFERS] = 'Standard error differs\n\
+Expected:\n{0}\nGot:\n{1}\n'
+        self.errmessages[ErrorType.RETURN_CODE_DIFFERS] = 'Return code differs\
+\nExpected:\n{0}\nGot:\n{1}\n'
+
+    def get_status_str(self, status):
+        return self.status_messages[status]
+
+    def get_error_str(self, error_type):
+        return self.errmessages[error_type]

--- a/airbag/messagebag.py
+++ b/airbag/messagebag.py
@@ -1,4 +1,4 @@
-from .status import ExitStatus
+from .status import ExitStatus, ChromeMessage as Chrome
 from .result import ErrorType
 
 
@@ -12,22 +12,31 @@ class MessageBag(object):
         self.status_messages[ExitStatus.timeout] = 'KO'
         self.status_messages[ExitStatus.noexec] = 'KO'
         self.errmessages = {}
-        self.errmessages[ErrorType.FILE_NOT_FOUND] = 'Couldn\'t find the progra\
-m {0}'
-        self.errmessages[ErrorType.NO_RIGHTS] = 'Couldn\'t execute the program \
-{0}'
-        self.errmessages[ErrorType.TIMEOUT] = 'Execution exceeded the {0}s time\
-out'
+        self.errmessages[ErrorType.FILE_NOT_FOUND] = 'Couldn\'t find the progr\
+am {0}'
+        self.errmessages[ErrorType.NO_RIGHTS] = 'Couldn\'t execute the program\
+ {0}'
+        self.errmessages[ErrorType.TIMEOUT] = 'Execution exceeded the {0}s tim\
+eout'
         self.errmessages[ErrorType.SIGNALED] = 'Killed by signal {0}'
-        self.errmessages[ErrorType.STDOUT_DIFFERS] = 'Standard output differs\n\
-Expected:\n{0}\nGot:\n{1}'
+        self.errmessages[ErrorType.STDOUT_DIFFERS] = 'Standard output differs\
+\nExpected:\n{0}\nGot:\n{1}'
         self.errmessages[ErrorType.STDERR_DIFFERS] = 'Standard error differs\n\
 Expected:\n{0}\nGot:\n{1}'
         self.errmessages[ErrorType.RETURN_CODE_DIFFERS] = 'Return code differs\
 \nExpected:\n{0}\nGot:\n{1}'
+        self.chrome_messages = {}
+        self.chrome_messages[Chrome.RAN_TESTS] = 'Ran {0} tests in {1:.1f} sec\
+onds.\n'
+        self.chrome_messages[Chrome.TESTS_STATS] = '[{0:.0f}%] Success: {1} | \
+Errors: {3} | Failures: {2}\n'
+        self.chrome_messages[Chrome.RAN_TEST] = '[{0}]{1}: {2}\n'
 
     def get_status_str(self, status):
         return self.status_messages[status]
 
     def get_error_str(self, error_type):
         return self.errmessages[error_type]
+
+    def get_chrome_str(self, chrome_type):
+        return self.chrome_messages[chrome_type]

--- a/airbag/result.py
+++ b/airbag/result.py
@@ -1,0 +1,30 @@
+from enum import Enum
+from airbag.status import ExitStatus
+
+
+class TestResult(object):
+    def __init__(self, name, program='', arguments=[]):
+        super(TestResult, self).__init__()
+        self.status = ExitStatus.OK
+        self.errors = []
+        self.name = name
+        self.program = program
+        self.arguments = arguments
+
+    def set_exit_status(self, exit_status):
+        self.status = exit_status
+        return self
+
+    def add_error(self, error_type, *args):
+        self.errors.append(dict(type=error_type, args=args))
+        return self
+
+
+class ErrorType(Enum):
+    FILE_NOT_FOUND = 1
+    NO_RIGHTS = 2
+    TIMEOUT = 3
+    SIGNALED = 4
+    STDOUT_DIFFERS = 5
+    STDERR_DIFFERS = 6
+    RETURN_CODE_DIFFERS = 7

--- a/airbag/status.py
+++ b/airbag/status.py
@@ -9,10 +9,7 @@ class ExitStatus(Enum):
     noexec = 5      # Program didn't execute
 
 
-class ProgramStatus(object):
-    """docstring for ProgramStatus"""
-    def __init__(self, outs, errs, program):
-        super(ProgramStatus, self).__init__()
-        self.outs = outs
-        self.errs = errs
-        self.returncode = program.returncode
+class ChromeMessage(Enum):
+    RAN_TESTS = 1
+    TESTS_STATS = 2
+    RAN_TEST = 3

--- a/airbag/status.py
+++ b/airbag/status.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 class ExitStatus(Enum):
-    ok = 1          # Program executed, finished & passed tests
+    OK = 1          # Program executed, finished & passed tests
     finished = 2    # Program executed, finished but didn't pass tests
     killed = 3      # Program executed and didn't finish
     timeout = 4     # Program executed and didn't finish due to timeout

--- a/airbag/testrunner.py
+++ b/airbag/testrunner.py
@@ -4,10 +4,10 @@ from .status import ExitStatus
 
 class TestRunner(object):
     """docstring for TestRunner"""
-    def __init__(self, tests, formatter):
+    def __init__(self, tests, formatters):
         super(TestRunner, self).__init__()
         self.tests = tests
-        self.formatter = formatter
+        self.formatters = formatters
         self.tests_results = []
         self.stats = dict(successes=0,
                           failures=0,
@@ -18,7 +18,8 @@ class TestRunner(object):
 
     def launch(self):
         self.stats['starttime'] = time()
-        self.formatter.started(self.stats)
+        for formatter in self.formatters:
+            formatter.started(self.stats)
         self.run_tests()
         self.stats['endtime'] = time()
         self.stats['elapsed'] = self.stats['endtime'] - self.stats['starttime']
@@ -27,13 +28,15 @@ class TestRunner(object):
         if self.stats['tests'] > 0:
             ratio = self.stats['success'] / self.stats['tests']
             self.stats['percentage'] = ratio * 100
-        self.formatter.ended(self.tests_results, self.stats)
+        for formatter in self.formatters:
+            formatter.ended(self.tests_results, self.stats)
         return self.stats['failures']
 
     def run_tests(self):
         for test in self.tests:
             result = test.run()
-            self.formatter.ran(result, self.stats)
+            for formatter in self.formatters:
+                formatter.ran(result, self.stats)
             if result.status is ExitStatus.OK:
                 continue
             elif result.status in (

--- a/airbag/testrunner.py
+++ b/airbag/testrunner.py
@@ -10,11 +10,11 @@ class TestRunner(object):
         self.formatter = formatter
         self.tests_results = []
         self.stats = dict(successes=0,
-                failures=0,
-                errors=0,
-                percentage=0,
-                tests=len(tests)
-        )
+                          failures=0,
+                          errors=0,
+                          percentage=0,
+                          tests=len(tests)
+                          )
 
     def launch(self):
         self.stats['starttime'] = time()
@@ -22,19 +22,21 @@ class TestRunner(object):
         self.run_tests()
         self.stats['endtime'] = time()
         self.stats['elapsed'] = self.stats['endtime'] - self.stats['starttime']
-        self.stats['success'] = self.stats['tests'] - (self.stats['failures'] + self.stats['errors'])
+        self.stats['success'] = self.stats['tests'] - (self.stats['failures'] +
+                                                       self.stats['errors'])
         if self.stats['tests'] > 0:
-            self.stats['percentage'] = self.stats['success'] / self.stats['tests'] * 100
+            ratio = self.stats['success'] / self.stats['tests']
+            self.stats['percentage'] = ratio * 100
         self.formatter.ended(self.tests_results, self.stats)
         return self.stats['failures']
 
     def run_tests(self):
         for test in self.tests:
-            status = test.run()
-            self.formatter.ran({}, self.stats)
-            if status is ExitStatus.ok:
+            result = test.run()
+            self.formatter.ran(result, self.stats)
+            if result.status is ExitStatus.OK:
                 continue
-            elif status in (
+            elif result.status in (
                 ExitStatus.killed,
                 ExitStatus.timeout,
                 ExitStatus.noexec
@@ -42,4 +44,3 @@ class TestRunner(object):
                 self.stats['failures'] += 1
             else:
                 self.stats['errors'] += 1
-        

--- a/airbag_cli/cli.py
+++ b/airbag_cli/cli.py
@@ -1,6 +1,10 @@
+from airbag.status import ExitStatus
+
+
 class CliFormatter(object):
-    def __init__(self):
+    def __init__(self, message_bag):
         super(CliFormatter, self).__init__()
+        self.message_bag = message_bag
 
     def batch(self, tests_results, tests_stats):
         self.started(tests_stats)
@@ -9,10 +13,22 @@ class CliFormatter(object):
         self.ended(tests_results, tests_stats)
 
     def started(self, tests_stats):
-        print(tests_stats)
+        pass
 
     def ran(self, test_result, tests_stats):
-        print(test_result)
+        state = self.message_bag.get_status_str(test_result.status)
+        print('[{0}]{1}: {2}'.format(
+            test_result.program,
+            test_result.name,
+            state
+        ))
+        if test_result.status == ExitStatus.finished:
+            for error in test_result.errors:
+                print(
+                    self.message_bag
+                        .get_error_str(error['type'])
+                        .format(*(error['args']))
+                )
 
     def ended(self, tests_results, tests_stats):
         print(
@@ -31,4 +47,3 @@ class CliFormatter(object):
 
     def get_type():
         return 'cli'
-

--- a/airbag_cli/cli.py
+++ b/airbag_cli/cli.py
@@ -1,0 +1,34 @@
+class CliFormatter(object):
+    def __init__(self):
+        super(CliFormatter, self).__init__()
+
+    def batch(self, tests_results, tests_stats):
+        self.started(tests_stats)
+        for result in tests_results:
+            self.ran(result, tests_stats)
+        self.ended(tests_results, tests_stats)
+
+    def started(self, tests_stats):
+        print(tests_stats)
+
+    def ran(self, test_result, tests_stats):
+        print(test_result)
+
+    def ended(self, tests_results, tests_stats):
+        print(
+            'Ran {0} tests in {1:.1f} seconds.'.format(
+                tests_stats['tests'], tests_stats['elapsed']
+            )
+        )
+        print(
+            '[{0:.0f}%] Success: {1} | Errors: {3} | Failures: {2}'.format(
+                tests_stats['percentage'],
+                tests_stats['success'],
+                tests_stats['failures'],
+                tests_stats['errors']
+            )
+        )
+
+    def get_type():
+        return 'cli'
+

--- a/airbag_cli/cli.py
+++ b/airbag_cli/cli.py
@@ -2,9 +2,10 @@ from airbag.status import ExitStatus
 
 
 class CliFormatter(object):
-    def __init__(self, message_bag):
+    def __init__(self, message_bag, stream):
         super(CliFormatter, self).__init__()
         self.message_bag = message_bag
+        self.stream = stream
 
     def batch(self, tests_results, tests_stats):
         self.started(tests_stats)
@@ -17,27 +18,27 @@ class CliFormatter(object):
 
     def ran(self, test_result, tests_stats):
         state = self.message_bag.get_status_str(test_result.status)
-        print('[{0}]{1}: {2}'.format(
+        self.stream.write('[{0}]{1}: {2}\n'.format(
             test_result.program,
             test_result.name,
             state
         ))
         if test_result.status == ExitStatus.finished:
             for error in test_result.errors:
-                print(
-                    self.message_bag
+                self.stream.write(
+                   self.message_bag
                         .get_error_str(error['type'])
-                        .format(*(error['args']))
+                        .format(*(error['args'])) + '\n'
                 )
 
     def ended(self, tests_results, tests_stats):
-        print(
-            'Ran {0} tests in {1:.1f} seconds.'.format(
+        self.stream.write(
+            'Ran {0} tests in {1:.1f} seconds.\n'.format(
                 tests_stats['tests'], tests_stats['elapsed']
             )
         )
-        print(
-            '[{0:.0f}%] Success: {1} | Errors: {3} | Failures: {2}'.format(
+        self.stream.write(
+            '[{0:.0f}%] Success: {1} | Errors: {3} | Failures: {2}\n'.format(
                 tests_stats['percentage'],
                 tests_stats['success'],
                 tests_stats['failures'],

--- a/airbag_cli/cli.py
+++ b/airbag_cli/cli.py
@@ -1,4 +1,4 @@
-from airbag.status import ExitStatus
+from airbag.status import ExitStatus, ChromeMessage as Chrome
 
 
 class CliFormatter(object):
@@ -18,11 +18,13 @@ class CliFormatter(object):
 
     def ran(self, test_result, tests_stats):
         state = self.message_bag.get_status_str(test_result.status)
-        self.stream.write('[{0}]{1}: {2}\n'.format(
-            test_result.program,
-            test_result.name,
-            state
-        ))
+        self.stream.write(
+            self.message_bag.get_chrome_str(Chrome.RAN_TEST).format(
+                test_result.program,
+                test_result.name,
+                state
+            )
+        )
         if test_result.status == ExitStatus.finished:
             for error in test_result.errors:
                 self.stream.write(
@@ -33,12 +35,12 @@ class CliFormatter(object):
 
     def ended(self, tests_results, tests_stats):
         self.stream.write(
-            'Ran {0} tests in {1:.1f} seconds.\n'.format(
+            self.message_bag.get_chrome_str(Chrome.RAN_TESTS).format(
                 tests_stats['tests'], tests_stats['elapsed']
             )
         )
         self.stream.write(
-            '[{0:.0f}%] Success: {1} | Errors: {3} | Failures: {2}\n'.format(
+            self.message_bag.get_chrome_str(Chrome.TESTS_STATS).format(
                 tests_stats['percentage'],
                 tests_stats['success'],
                 tests_stats['failures'],

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,8 @@ setup(
         toml=airbag_toml.toml:TomlConfig [toml]
         [airbag.runners]
         prgm=airbag_program.runner:ProgramTest
+        [airbag.formatters]
+        cli=airbag_cli.cli:CliFormatter
     ''',
     extras_require={
         'toml': ['pytoml>=0.1.2']


### PR DESCRIPTION
Add support for custom formatters.
Needs cleaning of the runner who is currently in charge of outputting errors and failures.
This task is now delegated to the formatter. The formatter's constructor takes in parameter a MessageBag instance containing all the messages, making it easier to support multiple languages.
